### PR TITLE
微博API调整

### DIFF
--- a/weiboPicDownloader.py
+++ b/weiboPicDownloader.py
@@ -44,8 +44,8 @@ def get_urls(containerid, page):
     url = URL_TEMPLATE_PAGE.format(containerid, page)
     resp_text = get(url=url).text
     json_data = json.loads(resp_text)
-    cards = json_data['cards']
-    if not cards:
+    cards = json_data['data']['cards']
+    if json_data['ok'] != 1: 
         return None
     photos = []
     for card in cards:
@@ -78,13 +78,14 @@ def handle_user(nickname):
         return
     all = []
     page = 0
-    has_more = True
-    while has_more:
+    while True:
         page += 1
         urls = get_urls(containerid=cid, page=page)
-        has_more = bool(urls)
-        if has_more:
+        # has_more = bool(urls)
+        if urls != None:
             all.extend(urls)
+        else:
+            break
     count = len(all)
     for index, url in enumerate(all):
         print('{} {}/{}'.format(nickname, index, count))


### PR DESCRIPTION
- 17年末api返回json结构调整适配
```
{
  "ok": 1,
  "data": {旧结构},
  "showAppTips": 0,
  "scheme": "..."
}
```
- 获取照片集逻辑微调

旧逻辑若某一页没有**原创带图微博**不会继续下一页
比如整一页都是转发的，或者原创纯文字微博
用新结构中```ok```值可以准确判断